### PR TITLE
Fix wrong directory on subfile lookup

### DIFF
--- a/lib/find.js
+++ b/lib/find.js
@@ -85,7 +85,7 @@ var getTimezone = function (lat, lon) {
       // exact boundaries saved in file
       // parse geojson for exact boundaries
       var filepath = quadPos.split('').join('/')
-      var data = new Pbf(fs.readFileSync('./data/' + filepath + '/geo.buf'))
+      var data = new Pbf(fs.readFileSync(__dirname + '/../data/' + filepath + '/geo.buf'))
       var geoJson = geobuf.decode(data)
 
       for (var i = 0; i < geoJson.features.length; i++) {

--- a/lib/update.js
+++ b/lib/update.js
@@ -9,8 +9,8 @@ var yauzl = require('yauzl')
 var indexGeoJSON = require('./createGeoIndex.js')
 
 var TARGET_INDEX_PERCENT = 0.5
-var dlFile = 'downloads/timezones.zip'
-var tzFile = 'downloads/timezones.json'
+var dlFile = __dirname + '/../downloads/timezones.zip'
+var tzFile = __dirname + '/../downloads/timezones.json'
 
 var downloadLatest = function (callback) {
   console.log('Downloading geojson')
@@ -69,7 +69,7 @@ module.exports = function (cfg, callback) {
     }
   }
 
-  var dataDir = cfg.dataDir || './data'
+  var dataDir = cfg.dataDir || __dirname + '/../data'
 
   async.auto({
     // download latest geojson data
@@ -108,7 +108,7 @@ module.exports = function (cfg, callback) {
       })
     }],
     createIndex: ['deleteIndexFoldersAndFiles', 'unzipGeoJson', function (results, cb) {
-      indexGeoJSON(require('../' + tzFile), dataDir, TARGET_INDEX_PERCENT, cb)
+      indexGeoJSON(require(tzFile), dataDir, TARGET_INDEX_PERCENT, cb)
     }]
   }, callback)
 }

--- a/tests/find.test.js
+++ b/tests/find.test.js
@@ -4,6 +4,8 @@ var assert = require('chai').assert
 
 var geoTz = require('../index.js')
 
+process.chdir('/tmp')
+
 describe('find tests', function () {
   it('should find the timezone name for a valid coordinate', function () {
     var tz = geoTz.tz(47.650499, -122.350070)

--- a/tests/geoIndex.test.js
+++ b/tests/geoIndex.test.js
@@ -9,7 +9,7 @@ var util = require('./util.js')
 
 var createGeoIndex = require('../lib/createGeoIndex.js')
 
-var TEST_DATA_DIR = './data-test-geoindex'
+var TEST_DATA_DIR = __dirname + '/../data-test-geoindex'
 var testTzData = require('./data/largeTz.json')
 var expectedIndexData = require('./data/expectedIndexData.json')
 
@@ -30,7 +30,7 @@ describe('geoindex', function () {
       function (err) {
         assert.isNotOk(err)
 
-        var generatedIndex = require('.' + TEST_DATA_DIR + '/index.json')
+        var generatedIndex = require(TEST_DATA_DIR + '/index.json')
 
         assert.deepEqual(generatedIndex, expectedIndexData)
 

--- a/tests/update.test.js
+++ b/tests/update.test.js
@@ -10,7 +10,7 @@ var util = require('./util.js')
 var update = require('../lib/update.js')
 
 var TEST_DATA_DIR = './data-test-update'
-var LOCAL_FOLDER = './tests/data/'
+var LOCAL_FOLDER = __dirname + '/../tests/data/'
 
 describe('data update', function () {
   this.timeout(4000)


### PR DESCRIPTION
Hi there!

I kept getting this error:
```javascript
> geoTz.tz(-33.8567799, 151.213108)
Error: ENOENT: no such file or directory, open './data/a/d/c/c/d/c/b/geo.buf'
```

After some examination I discovered that this line is responsible:
```javascript
var data = new Pbf(fs.readFileSync('./data/' + filepath + '/geo.buf'))
```

Unfortunately, unlike `require`, `readFileSync` resolves paths relative to the current directory (ie `process.cwd()`), *not* the directory the module is in (ie, `__dirname`).

The tests still passed, unfortunately, because when you run them your current directory is the root of the project, so `./data` resolves just fine. Unfortunately, it breaks when you use it anywhere else.

I fixed the error, and to avoid that category of error in future I also added a `process.chdir('/tmp')` to the start of the find test (and I had to make a few adjustments to tests that expected the cwd to be the root of the project).