### PR TITLE
Geojson data fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The most up-to-date and accurate node.js geographical timezone lookup package.  
 
 ## API Docs:
 
-As of Version 5, the API now returns a list of possible timezones as there are certain coordinates where the timekeeping method will depend on the person you ask.
+As of Version 5, the API now returns a list of possible timezones. There are certain coordinates where the timekeeping method will depend on the person you ask. Also, another case where 2 or more timezones could be returned is when a request is made with a coordinate that happens to be exactly on the border between two or more timezones.
 
 ### geoTz(lat, lon)
 

--- a/lib/find.js
+++ b/lib/find.js
@@ -74,17 +74,25 @@ const oceanZones = [
 ]
 
 var getTimezoneAtSea = function (lon) {
+  // coordinates along the 180 longitude should return two zones
+  if (lon === -180 || lon === 180) {
+    return ['Etc/GMT+12', 'Etc/GMT-12']
+  }
+  const tzs = []
   for (var i = 0; i < oceanZones.length; i++) {
     var z = oceanZones[i]
     if (z.left <= lon && z.right >= lon) {
-      return z.tzid
+      tzs.push(z.tzid)
+    } else if (z.right < lon) {
+      break
     }
   }
+  return tzs
 }
 
-var getTimezone = function (lat, lon) {
-  lat = parseFloat(lat)
-  lon = parseFloat(lon)
+var getTimezone = function (originalLat, originalLon) {
+  let lat = parseFloat(originalLat)
+  let lon = parseFloat(originalLon)
 
   var err
 
@@ -101,15 +109,15 @@ var getTimezone = function (lat, lon) {
   }
 
   // fix edges of the world
-  if (lat === 90) {
+  if (lat >= 89.9999) {
     lat = 89.9999
-  } else if (lat === -90) {
+  } else if (lat <= -89.9999) {
     lat = -89.9999
   }
 
-  if (lon === 180) {
+  if (lon >= 179.9999) {
     lon = 179.9999
-  } else if (lon === -180) {
+  } else if (lon <= -179.9999) {
     lon = -179.9999
   }
 
@@ -154,7 +162,7 @@ var getTimezone = function (lat, lon) {
     // analyze result of current depth
     if (!curTzData) {
       // no timezone in this quad, therefore must be timezone at sea
-      return getTimezoneAtSea(lon)
+      return getTimezoneAtSea(originalLon)
     } else if (curTzData === 'f') {
       // get exact boundaries
       var geoJson = featureCache.get(quadPos)
@@ -175,7 +183,7 @@ var getTimezone = function (lat, lon) {
       // otherwise must be timezone at sea
       return timezonesContainingPoint.length > 0
         ? timezonesContainingPoint
-        : getTimezoneAtSea(lon)
+        : getTimezoneAtSea(originalLon)
     } else if (curTzData.length > 0) {
       // exact match found
       return curTzData.map(idx => tzData.timezones[idx])

--- a/lib/geo-index.js
+++ b/lib/geo-index.js
@@ -21,9 +21,50 @@ module.exports = function (tzGeojson, dataDir, targetIndexPercent, callback) {
     lookup: {}
   }
 
-  const timezoneGeometries = tzGeojson.features.map(feature =>
-    geoJsonReader.read(JSON.stringify(feature.geometry))
-  )
+  /**
+   * iterate through geometry coordinates and change any coordinates along
+   * longitude 0 to longitude 0.00001
+   */
+  function hackLongitude0Polygon (polygon) {
+    polygon.forEach(linearRing => {
+      linearRing.forEach(ringCoords => {
+        if (ringCoords[0] === 0 && ringCoords[1] < -55) {
+          ringCoords[0] = 0.00001
+        }
+      })
+    })
+  }
+
+  const timezoneGeometries = tzGeojson.features.map(feature => {
+    // Perform a quick hack to make sure two Antarctic zones can be indexed
+    // properly. Each of these zones shares a boundary at longitude 0. During
+    // the quadtree analysis, the zones were being intersected right aloing
+    // their boundaries which resulted in LineStrings being returned. This hack
+    // changes their boundares along longitude 0 to longitude 0.00001 to avoid
+    // LineStrings being intersected.
+    if (
+      feature.properties.tzid === 'Africa/Johannesburg' ||
+        feature.properties.tzid === 'Antarctica/Troll'
+    ) {
+      if (feature.geometry.type === 'MultiPolygon') {
+        feature.geometry.coordinates.forEach(hackLongitude0Polygon)
+      } else {
+        hackLongitude0Polygon(feature.geometry.coordinates)
+      }
+    }
+
+    // load zone into memory as jsts geometry
+    return geoJsonReader.read(JSON.stringify(feature.geometry))
+  })
+
+  var debugWriteIdx = 1
+
+  var writeDebugData = function (filename, geom) {
+    fs.writeFileSync(
+      'debug_' + debugWriteIdx + '_' + filename + '.json',
+      JSON.stringify(geoJsonWriter.write(geom))
+    )
+  }
 
   var getIntersectingGeojson = function (tzIdx, curBoundsGeometry) {
     // console.log('intersecting', tzGeojson.features[tzIdx].properties)
@@ -36,6 +77,19 @@ module.exports = function (tzGeojson, dataDir, targetIndexPercent, callback) {
     ) {
       return undefined
     } else {
+      const tzName = data.timezones[tzIdx]
+      // If the geojson type is not a Polygon or a MultiPolygon, something weird
+      // is happening and the build should be failed as this will cause issues
+      // during the find method.
+      // See https://github.com/evansiroky/node-geo-tz/issues/90.
+      if (!intersectedGeoJson.type.match(/olyg/)) {
+        console.log(tzName)
+        console.log(intersectedGeoJson.type)
+        writeDebugData('tz', timezoneGeometries[tzIdx])
+        writeDebugData('curBounds', curBoundsGeometry)
+        writeDebugData('intersection', intersectedGeometry)
+        debugWriteIdx++
+      }
       return {
         type: 'Feature',
         properties: {},
@@ -355,7 +409,13 @@ module.exports = function (tzGeojson, dataDir, targetIndexPercent, callback) {
 
   fileWritingQueue.drain = function (err) {
     console.log('done indexing')
-    callback(err)
+    callback(
+      err || (
+        debugWriteIdx > 1
+          ? 'At least one unexpected intersected geometry type encountered!'
+          : null
+      )
+    )
   }
 
   // write index data to file

--- a/lib/update.js
+++ b/lib/update.js
@@ -32,8 +32,9 @@ var downloadLatest = function (callback) {
           res.on('end', function () {
             data = JSON.parse(data)
             for (var i = 0; i < data.assets.length; i++) {
-              data.assets[i].browser_download_url.indexOf('timezones.geojson') > -1
-              return cb(null, data.assets[i].browser_download_url)
+              if (data.assets[i].browser_download_url.indexOf('timezones.geojson') > -1) {
+                return cb(null, data.assets[i].browser_download_url)
+              }
             }
             cb('geojson not found')
           })

--- a/tests/find.test.js
+++ b/tests/find.test.js
@@ -32,8 +32,28 @@ describe('find tests', function () {
     assertTzResultContainsTzs(1.44, 104.04, 'Asia/Singapore')
   })
 
-  it('should return null timezone name for coordinate in ocean', function () {
+  it('should return Etc/GMT timezone for coordinate in ocean', function () {
     assertTzResultContainsTzs(0, 0, 'Etc/GMT')
+  })
+
+  it('should return both timezones on an ocean coordinate at -180 longitude', function () {
+    assertTzResultContainsTzs(40, -180, ['Etc/GMT-12', 'Etc/GMT+12'])
+  })
+
+  it('should return both timezones on an ocean coordinate at +180 longitude', function () {
+    assertTzResultContainsTzs(40, 180, ['Etc/GMT-12', 'Etc/GMT+12'])
+  })
+
+  it('should return only one timezone on an ocean coordinate at +179.9999 longitude', function () {
+    assertTzResultContainsTzs(40, 179.9999, 'Etc/GMT-12')
+  })
+
+  it('should return only one timezones on an ocean coordinate at -179.9999 longitude', function () {
+    assertTzResultContainsTzs(40, -179.9999, 'Etc/GMT+12')
+  })
+
+  it('should return both timezone for coordinate in ocean on middle of boundary', function () {
+    assertTzResultContainsTzs(40, -157.5, ['Etc/GMT+10', 'Etc/GMT+11'])
   })
 
   describe('issue cases', function () {

--- a/tests/fixtures/issues.json
+++ b/tests/fixtures/issues.json
@@ -139,5 +139,15 @@
     "lat": 22.138993,
     "lon": 31.416836,
     "description": "#89 - 2019a - test for zone Asia/Khartoum in Sudanese part of Lake Nasser"
+  }, {
+    "zid": "America/Adak",
+    "lat": 52.031192,
+    "lon": 178.913872,
+    "description": "#90 - some file-based data was showing up as non-polygon geojson"
+  }, {
+    "zids": ["Africa/Johannesburg", "Antarctica/McMurdo", "Antarctica/Troll"],
+    "lat": -86,
+    "lon": 0.00001,
+    "description": "#90 - timezones that share the same corner should all be found when the coordinate corner is queried"
   }
 ]


### PR DESCRIPTION
This PR contains a bunch of fixes after #90 showed that this library was not working in some climatologically cold places.

The first item fixed was in the timezone of `America/Adak`. For some reason, this place had a GeometryCollection geojson type instead of the expected Polygon or MultiPolygon. After further examination, it was found that this library was not downloading the expected dataset from [timezone-boundary-builder](https://github.com/evansiroky/timezone-boundary-builder). It was downloading the first found geojson item which luckily happened to be the geojson-with-oceans. This library is designed to use the geojson without the ocean data as the ocean data merely duplicates the territorial water boundaries already found in the other zones. Therefore, this was corrected by making sure that the geojson without oceans is downloaded and used to build the data.

The second issue was the matter of LineStrings showing up as possible boundaries to intersect with. This was primarily happening with the boundaries between `Antarctica/Troll` and `Africa/Johannesburg`. The geo-indexing process was starting out on longitude 0 which just happens to be the dividing line between part of those 2 zones. Therefore, the intersection of various subareas between these 2 zones did result in a LineString since the intersection area shared the border as well. This is somewhat unavoidable due to the underlying data, so a hack was made to shift the border of these two zones from longitude 0 to longitude 0.00001. Now, the geo-index will always find a polygon when intersecting these zones.

Finally, a number of edges cases in the oceans were not completely working as expected. The finding algorithm was modified to return the correct ocean zones on certain edge cases such as returning both `Etc/GMT+12` and `Etc/GMT-12` on longitude 180 or -180. Also, both zones are now returned in places where a coordinate along the boundary of the two zones is requested.