### PR TITLE
rework caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,22 +29,25 @@ This library does an exact geographic lookup which has tradeoffs.  It is perhaps
 
 The data is indexed for fast analysis by caching subregions of geographic data when a precise lookup is needed.
 
-### geoTz.setCache()
+### geoTz.setCache(options || false)
 
-Changes the caching behavior. The following caching schemes are available:
+By default, geoTz uses a cache that expires after 60 seconds. This method can be used to change the caching behavior using the following options:
+
+* `expires` - time in miliseconds to expire a cached file (cannot be used together with `store`)
+* `preload` - if set to true will attempt to cache all files (requires lots of memory)
+* `store` - offload the cache to a custom storage solution (must be compatible with the Map api)
+
+Examples:
 
 ```js
-geoTz.setCache(0)  // disable caching. Files will always be loaded from disk
-geoTz.setCache(1)  // default. Files will be cached for 1 minute
-geoTz.setCache(2)  // Files will be cached for 1 hour
-geoTz.setCache(3)  // Files will be cached for 24 hours
-geoTz.setCache(4)  // Files will be cached forever
-geoTz.setCache(5)  // Files will be cached forever and all files will be preloaded (requires several hundred MB of ram)
+geoTz.setCache(false) // disable caching
+geoTz.setCache({expires:120000}) // cache expires after 2 minutes
+geoTz.setCache({expires:0}) // cache never expires
+geoTz.setCache({expires:0,preload:true}) // cache never expires and preloads all files
 
-let store = new Map()
-geoTz.setCache(store)  // Custom cache store, must be compatible with the Map api
+let map = new Map();
+geoTz.setCache({store:map}) // pass a Map-like storage object
 ```
-Higher cache level will generally consume more memory but consecutive lookups will be a lot faster. Alternatively a custom cache store can be supplied, which can be used to offload caching to a key value database like redis.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,9 @@ The most up-to-date and accurate node.js geographical timezone lookup package.  
 
 ## Usage
 
-```javascript
-    var geoTz = require('geo-tz')
+```js
+    const geoTz = require('geo-tz')
 
-    geoTz.cacheLevel(5)  // optionally change cache level, defaults to 1
     geoTz(47.650499, -122.350070)  // ['America/Los_Angeles']
     geoTz(43.839319, 87.526148)  // ['Asia/Shanghai', 'Asia/Urumqi']
 ```
@@ -34,7 +33,7 @@ The data is indexed for fast analysis by caching subregions of geographic data w
 By default, geoTz uses a cache that expires after 60 seconds. This method can be used to change the caching behavior using the following options:
 
 * `expires` - time in miliseconds to expire a cached file (cannot be used together with `store`)
-* `preload` - if set to true will attempt to cache all files (requires lots of memory)
+* `preload` - if set to true will attempt to cache all files (slow startup time and requires lots of memory)
 * `store` - offload the cache to a custom storage solution (must be compatible with the Map api)
 
 Examples:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Returns the timezone names found at `lat`, `lon`.  The timezone names will be th
 
 This library does an exact geographic lookup which has tradeoffs.  It is perhaps a little bit slower that other libraries, has a larger installation size on disk and cannot be used in the browser.  However, the results are more accurate than other libraries that compromise by approximating the lookup of the data.
 
-The data is indexed for fast analysis with automatic caching with time expiration (or optional an unexpiring cache of the whole world) of subregions of geographic data for when a precise lookup is needed.
+The data is indexed for fast analysis by caching subregions of geographic data when a precise lookup is needed.
 
 ### geoTz.cacheLevel()
 

--- a/README.md
+++ b/README.md
@@ -29,19 +29,22 @@ This library does an exact geographic lookup which has tradeoffs.  It is perhaps
 
 The data is indexed for fast analysis by caching subregions of geographic data when a precise lookup is needed.
 
-### geoTz.cacheLevel()
+### geoTz.setCache()
 
 Changes the caching behavior. The following caching schemes are available:
 
 ```js
-geoTz.cacheLevel(0)  // disable caching. Files will always be loaded from disk
-geoTz.cacheLevel(1)  // default. Files will be cached for 1 minute
-geoTz.cacheLevel(2)  // Files will be cached for 1 hour
-geoTz.cacheLevel(3)  // Files will be cached for 24 hours
-geoTz.cacheLevel(4)  // Files will be cached forever
-geoTz.cacheLevel(5)  // Files will be cached forever and all files will be preloaded (requires several hundred MB of ram)
+geoTz.setCache(0)  // disable caching. Files will always be loaded from disk
+geoTz.setCache(1)  // default. Files will be cached for 1 minute
+geoTz.setCache(2)  // Files will be cached for 1 hour
+geoTz.setCache(3)  // Files will be cached for 24 hours
+geoTz.setCache(4)  // Files will be cached forever
+geoTz.setCache(5)  // Files will be cached forever and all files will be preloaded (requires several hundred MB of ram)
+
+let store = new Map()
+geoTz.setCache(store)  // Custom cache store, must be compatible with the Map api
 ```
-Higher cache level will generally consume more memory but repeated lookups will be a lot faster.
+Higher cache level will generally consume more memory but consecutive lookups will be a lot faster. Alternatively a custom cache store can be supplied, which can be used to offload caching to a key value database like redis.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The most up-to-date and accurate node.js geographical timezone lookup package.  
 ```javascript
     var geoTz = require('geo-tz')
 
-    geoTz.preCache()  // optionally load all features into memory
+    geoTz.cacheLevel(5)  // optionally change cache level, defaults to 1
     geoTz(47.650499, -122.350070)  // ['America/Los_Angeles']
     geoTz(43.839319, 87.526148)  // ['Asia/Shanghai', 'Asia/Urumqi']
 ```
@@ -29,9 +29,19 @@ This library does an exact geographic lookup which has tradeoffs.  It is perhaps
 
 The data is indexed for fast analysis with automatic caching with time expiration (or optional an unexpiring cache of the whole world) of subregions of geographic data for when a precise lookup is needed.
 
-### geoTz.preCache()
+### geoTz.cacheLevel()
 
-Loads all geographic features into memory in an unexpiring cache.  This has tradeoffs.  More memory will be consumed and it will take a little longer before the program is ready to start looking up features, but future lookups will be a lot faster - especially for areas which haven't had a lookup in a while.
+Changes the caching behavior. The following caching schemes are available:
+
+```js
+geoTz.cacheLevel(0)  // disable caching. Files will always be loaded from disk
+geoTz.cacheLevel(1)  // default. Files will be cached for 1 minute
+geoTz.cacheLevel(2)  // Files will be cached for 1 hour
+geoTz.cacheLevel(3)  // Files will be cached for 24 hours
+geoTz.cacheLevel(4)  // Files will be cached forever
+geoTz.cacheLevel(5)  // Files will be cached forever and all files will be preloaded (requires several hundred MB of ram)
+```
+Higher cache level will generally consume more memory but repeated lookups will be a lot faster.
 
 ## Limitations
 

--- a/lib/find.js
+++ b/lib/find.js
@@ -10,50 +10,6 @@ var point = require('@turf/helpers').point
 var tzData = require('../data/index.json')
 const {getTimezoneAtSea, oceanZones} = require('./oceanUtils')
 
-
-/**
- * Custom cache class that normalizes behavior between the Map api and the timed-cache api
- * Define 5 cache levels
- * 0 = no cache, files will always be loaded from disk when needed
- * 1 = timed-cache, expires after 1 minute
- * 2 = timed-cache, expires after 1 hour
- * 3 = timed-cache, expires after 1 day
- * 4 = Map cache, never expires
- * 5 = Map cache, never expires, preload all files
- */
-class Cache {
-  constructor(v) {
-    if(v == 0) {
-      this.level = 0
-    } else if(v == 1) {
-      this.level = 1
-      this.data = new timedCache()
-    } else if(v == 2) {
-      this.level = 2
-      this.data = new timedCache({ defaultTtl: 1000*60*60 })
-    } else if(v == 3) {
-      this.level = 3
-      this.data = new timedCache({ defaultTtl: 1000*60*60*24 })
-    } else if(v == 4) {
-      this.level = 4
-      this.data = new Map()
-    } else if(v == 5) {
-      this.level = 5
-      this.data = new Map()
-      preCache();
-    }
-  }
-  set(k,v) {
-    if(this.level === 0) return undefined
-    if(this.level < 4) return this.data.put(k,v)
-    if(this.level < 6) return this.data.set(k,v)
-  }
-  get(k) {
-    if(this.level === 0) return undefined;
-    return this.data.get(k)
-  }
-}
-
 let featureCache = new Cache(1)
 
 /**
@@ -199,9 +155,59 @@ var getTimezone = function (originalLat, originalLon) {
   }
 }
 
+/**
+ * Custom cache class that normalizes behavior between the Map api and the timed-cache api
+ * Define 5 cache levels
+ * 0 = no cache, files will always be loaded from disk when needed
+ * 1 = default, timed-cache, expires after 1 minute
+ * 2 = timed-cache, expires after 1 hour
+ * 3 = timed-cache, expires after 1 day
+ * 4 = Map cache, never expires
+ * 5 = Map cache, never expires, preload all files
+ */
+class Cache {
+  constructor(v) {
+    if(v == 0) {
+      this.level = 0
+    } else if(v == 1) {
+      this.level = 1
+      this.data = new timedCache()
+    } else if(v == 2) {
+      this.level = 2
+      this.data = new timedCache({ defaultTtl: 1000*60*60 })
+    } else if(v == 3) {
+      this.level = 3
+      this.data = new timedCache({ defaultTtl: 1000*60*60*24 })
+    } else if(v == 4) {
+      this.level = 4
+      this.data = new Map()
+    } else if(v == 5) {
+      this.level = 5
+      this.data = new Map()
+      preCache();
+    } else {
+      this.level = 1
+      this.data = new timedCache()
+    }
+  }
+  set(k,v) {
+    if(this.level === 0) return undefined
+    if(this.level < 4) return this.data.put(k,v)
+    if(this.level < 6) return this.data.set(k,v)
+  }
+  get(k) {
+    if(this.level === 0) return undefined;
+    return this.data.get(k)
+  }
+}
+
 function cacheLevel(v) {
-  featureCache = new Cache(v)
+  if(!isNaN(v)) {
+    featureCache = new Cache(v)
+  } else if(typeof v.get === "function" && typeof v.set === "function") {
+    featureCache = v
+  }
 }
 
 module.exports = getTimezone
-module.exports.cacheLevel = cacheLevel
+module.exports.setCache = cacheLevel

--- a/lib/find.js
+++ b/lib/find.js
@@ -3,29 +3,68 @@ var path = require('path')
 
 var geobuf = require('geobuf')
 var inside = require('@turf/boolean-point-in-polygon').default
-var Cache = require('timed-cache')
+var timedCache = require('timed-cache')
 var Pbf = require('pbf')
 var point = require('@turf/helpers').point
 
 var tzData = require('../data/index.json')
 const {getTimezoneAtSea, oceanZones} = require('./oceanUtils')
 
-let featureCache = new Cache()
+
+/**
+ * Custom cache class that normalizes behavior between the Map api and the timed-cache api
+ * Define 5 cache levels
+ * 0 = no cache, files will always be loaded from disk when needed
+ * 1 = timed-cache, expires after 1 minute
+ * 2 = timed-cache, expires after 1 hour
+ * 3 = timed-cache, expires after 1 day
+ * 4 = Map cache, never expires
+ * 5 = Map cache, never expires, preload all files
+ */
+class Cache {
+  constructor(v) {
+    if(v == 0) {
+      this.level = 0
+    } else if(v == 1) {
+      this.level = 1
+      this.data = new timedCache()
+    } else if(v == 2) {
+      this.level = 2
+      this.data = new timedCache({ defaultTtl: 1000*60*60 })
+    } else if(v == 3) {
+      this.level = 3
+      this.data = new timedCache({ defaultTtl: 1000*60*60*24 })
+    } else if(v == 4) {
+      this.level = 4
+      this.data = new Map()
+    } else if(v == 5) {
+      this.level = 5
+      this.data = new Map()
+      preCache();
+    }
+  }
+  set(k,v) {
+    if(this.level === 0) return undefined
+    if(this.level < 4) return this.data.put(k,v)
+    if(this.level < 6) return this.data.set(k,v)
+  }
+  get(k) {
+    if(this.level === 0) return undefined;
+    return this.data.get(k)
+  }
+}
+
+let featureCache = new Cache(1)
 
 /**
  * A function that will load all features into an unexpiring cache
  */
-var preCache = function () {
-  const _eternalCache = {}
-  featureCache = {
-    get: (quadPos) => _eternalCache[quadPos]
-  }
-
+function preCache() {
   // shoutout to github user @magwo for an initial version of this recursive function
   var preloadFeaturesRecursive = function (curTzData, quadPos) {
     if (curTzData === 'f') {
       var geoJson = loadFeatures(quadPos)
-      _eternalCache[quadPos] = geoJson
+      featureCache.set(quadPos,geoJson)
     } else if (typeof curTzData === 'object') {
       Object.getOwnPropertyNames(curTzData).forEach(function (value) {
         preloadFeaturesRecursive(curTzData[value], quadPos + value)
@@ -129,7 +168,7 @@ var getTimezone = function (originalLat, originalLon) {
       var geoJson = featureCache.get(quadPos)
       if (!geoJson) {
         geoJson = loadFeatures(quadPos)
-        featureCache.put(quadPos, geoJson)
+        featureCache.set(quadPos, geoJson)
       }
 
       var timezonesContainingPoint = []
@@ -160,5 +199,9 @@ var getTimezone = function (originalLat, originalLon) {
   }
 }
 
+function cacheLevel(v) {
+  featureCache = new Cache(v)
+}
+
 module.exports = getTimezone
-module.exports.preCache = preCache
+module.exports.cacheLevel = cacheLevel

--- a/lib/find.js
+++ b/lib/find.js
@@ -10,64 +10,35 @@ var point = require('@turf/helpers').point
 var tzData = require('../data/index.json')
 const {getTimezoneAtSea, oceanZones} = require('./oceanUtils')
 
+let featureCache;
+
 /**
- * Custom cache class that normalizes behavior between the Map api and the timed-cache api
- * Define 5 cache levels
- * 0 = no cache, files will always be loaded from disk when needed
- * 1 = default, timed-cache, expires after 1 minute
- * 2 = timed-cache, expires after 1 hour
- * 3 = timed-cache, expires after 1 day
- * 4 = Map cache, never expires
- * 5 = Map cache, never expires, preload all files
+ * Set caching behavior.
  */
-class Cache {
-  constructor(v) {
-    if(v == 0) {
-      this.level = 0
-    } else if(v == 1) {
-      this.level = 1
-      this.data = new timedCache()
-    } else if(v == 2) {
-      this.level = 2
-      this.data = new timedCache({ defaultTtl: 1000*60*60 })
-    } else if(v == 3) {
-      this.level = 3
-      this.data = new timedCache({ defaultTtl: 1000*60*60*24 })
-    } else if(v == 4) {
-      this.level = 4
-      this.data = new Map()
-    } else if(v == 5) {
-      this.level = 5
-      this.data = new Map()
-      preCache();
+function cacheLevel(options) {
+  if(options === false || options === null) {
+    featureCache = {
+      get: function() { return undefined },
+      set: function() { return undefined }
+    }
+  } else if(options.store && typeof options.store.get === "function" && typeof options.store.set === "function") {
+    featureCache = options.store
+  } else if(typeof options.expires === "number") {
+    if(options.expires === 0) {
+      featureCache = new Map()
     } else {
-      this.level = 1
-      this.data = new timedCache()
+      featureCache = new timedCache({ defaultTtl: options.expires })
+      featureCache.set = function(k,v) {
+        featureCache.put(k,v)
+      }
     }
   }
-  set(k,v) {
-    if(this.level === 0) return undefined
-    if(this.level < 4) return this.data.put(k,v)
-    if(this.level < 6) return this.data.set(k,v)
-  }
-  get(k) {
-    if(this.level === 0) return undefined;
-    return this.data.get(k)
+  if(options.preload) {
+    preCach()
   }
 }
 
-let featureCache = new Cache(1)
-
-/**
- * A function to change caching behavior
- */
-function cacheLevel(v) {
-  if(!isNaN(v)) {
-    featureCache = new Cache(v)
-  } else if(typeof v.get === "function" && typeof v.set === "function") {
-    featureCache = v
-  }
-}
+cacheLevel({expires:60000})
 
 /**
  * A function that will load all features into an unexpiring cache
@@ -214,3 +185,8 @@ var getTimezone = function (originalLat, originalLon) {
 
 module.exports = getTimezone
 module.exports.setCache = cacheLevel
+
+// for backwards compatibility
+module.exports.preCache = function() {
+  cacheLevel({expires:0,preload:true})
+}

--- a/lib/find.js
+++ b/lib/find.js
@@ -10,7 +10,64 @@ var point = require('@turf/helpers').point
 var tzData = require('../data/index.json')
 const {getTimezoneAtSea, oceanZones} = require('./oceanUtils')
 
+/**
+ * Custom cache class that normalizes behavior between the Map api and the timed-cache api
+ * Define 5 cache levels
+ * 0 = no cache, files will always be loaded from disk when needed
+ * 1 = default, timed-cache, expires after 1 minute
+ * 2 = timed-cache, expires after 1 hour
+ * 3 = timed-cache, expires after 1 day
+ * 4 = Map cache, never expires
+ * 5 = Map cache, never expires, preload all files
+ */
+class Cache {
+  constructor(v) {
+    if(v == 0) {
+      this.level = 0
+    } else if(v == 1) {
+      this.level = 1
+      this.data = new timedCache()
+    } else if(v == 2) {
+      this.level = 2
+      this.data = new timedCache({ defaultTtl: 1000*60*60 })
+    } else if(v == 3) {
+      this.level = 3
+      this.data = new timedCache({ defaultTtl: 1000*60*60*24 })
+    } else if(v == 4) {
+      this.level = 4
+      this.data = new Map()
+    } else if(v == 5) {
+      this.level = 5
+      this.data = new Map()
+      preCache();
+    } else {
+      this.level = 1
+      this.data = new timedCache()
+    }
+  }
+  set(k,v) {
+    if(this.level === 0) return undefined
+    if(this.level < 4) return this.data.put(k,v)
+    if(this.level < 6) return this.data.set(k,v)
+  }
+  get(k) {
+    if(this.level === 0) return undefined;
+    return this.data.get(k)
+  }
+}
+
 let featureCache = new Cache(1)
+
+/**
+ * A function to change caching behavior
+ */
+function cacheLevel(v) {
+  if(!isNaN(v)) {
+    featureCache = new Cache(v)
+  } else if(typeof v.get === "function" && typeof v.set === "function") {
+    featureCache = v
+  }
+}
 
 /**
  * A function that will load all features into an unexpiring cache
@@ -152,60 +209,6 @@ var getTimezone = function (originalLat, originalLon) {
     // calculate next quadtree depth data
     quadData.midLat = (quadData.top + quadData.bottom) / 2
     quadData.midLon = (quadData.left + quadData.right) / 2
-  }
-}
-
-/**
- * Custom cache class that normalizes behavior between the Map api and the timed-cache api
- * Define 5 cache levels
- * 0 = no cache, files will always be loaded from disk when needed
- * 1 = default, timed-cache, expires after 1 minute
- * 2 = timed-cache, expires after 1 hour
- * 3 = timed-cache, expires after 1 day
- * 4 = Map cache, never expires
- * 5 = Map cache, never expires, preload all files
- */
-class Cache {
-  constructor(v) {
-    if(v == 0) {
-      this.level = 0
-    } else if(v == 1) {
-      this.level = 1
-      this.data = new timedCache()
-    } else if(v == 2) {
-      this.level = 2
-      this.data = new timedCache({ defaultTtl: 1000*60*60 })
-    } else if(v == 3) {
-      this.level = 3
-      this.data = new timedCache({ defaultTtl: 1000*60*60*24 })
-    } else if(v == 4) {
-      this.level = 4
-      this.data = new Map()
-    } else if(v == 5) {
-      this.level = 5
-      this.data = new Map()
-      preCache();
-    } else {
-      this.level = 1
-      this.data = new timedCache()
-    }
-  }
-  set(k,v) {
-    if(this.level === 0) return undefined
-    if(this.level < 4) return this.data.put(k,v)
-    if(this.level < 6) return this.data.set(k,v)
-  }
-  get(k) {
-    if(this.level === 0) return undefined;
-    return this.data.get(k)
-  }
-}
-
-function cacheLevel(v) {
-  if(!isNaN(v)) {
-    featureCache = new Cache(v)
-  } else if(typeof v.get === "function" && typeof v.set === "function") {
-    featureCache = v
   }
 }
 

--- a/lib/find.js
+++ b/lib/find.js
@@ -34,7 +34,7 @@ function cacheLevel(options) {
     }
   }
   if(options.preload) {
-    preCach()
+    preCache()
   }
 }
 


### PR DESCRIPTION
Hello,

As discussed earlier, this PR reworks the caching system and introduces some useful QOL stuff.

I suggest eventually dropping `timed-cache` altogether and either giving such control back to the user via custom stores or writing an internal timer for expiration.

Cheers!

Off-topic: any plans for tzdata 2019c soon? Thanks!