### PR TITLE
Travis-CI no longer support node 6,7,9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,7 @@ node_js:
   - "12"
   - "11"
   - "10"
-  - "9"
   - "8"
-  - "7"
-  - "6"
 
 env:
   - COVERAGE=false
@@ -16,13 +13,13 @@ env:
 matrix:
   fast_finish: true
   include:
-    - node_js: "6"
+    - node_js: "10"
       env: COVERAGE=true
       script:
         - "npm run cover"
         - bash <(curl -s https://codecov.io/bash)
   allow_failures:
-    - node_js: "6"
+    - node_js: "10"
       env: COVERAGE=true
       script:
         - "npm run cover"


### PR DESCRIPTION
On my previous PR lots node versions failed on Travis CI https://travis-ci.com/mtmail/node-geo-tz/builds/148871795 e.g. "npm does not support Node.js v7.10.1"

I can only guess which node versions you want to target https://nodejs.org/en/about/releases/

https://docs.travis-ci.com/user/reference/bionic/#javascript-and-nodejs-support
"The following NodeJS versions are preinstalled: 12.13.1, 11.15.0, 10.16.0, and 8.16.2."

