### PR TITLE
feat: add type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,32 @@
+export default geo_tz;
+
+interface IGeometry {
+  type: string;
+  coordinates: number[];
+}
+
+interface IGeoJson {
+  type: string;
+  geometry: IGeometry;
+  bbox?: number[];
+  properties?: any;
+}
+
+type MapLike = {
+  get: (key: string) => IGeoJson;
+  set: (key: string, payload: IGeoJson) => MapLike;
+};
+
+type CacheStore = Map<string, IGeoJson> | MapLike;
+
+declare function geo_tz(lat: number, lon: number): string[];
+
+declare namespace geo_tz {
+  function setCache({
+    preload,
+    store,
+  }: {
+    preload?: boolean;
+    store?: CacheStore;
+  }): void;
+}


### PR DESCRIPTION
This PR adds a type definition file for the package. The default export has very simple types, but the `store` property in the `setCache` method has relatively complex nested types. I attempted to capture all of the details of input and output from the store functions based on the code, but I'm not 100% that they are exactly correct. Let me know if you have any feedback or requests!