### PR TITLE
Remove default export in favor of named exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,19 @@ The most up-to-date and accurate node.js geographical timezone lookup package.  
 ## Usage
 
 ```js
-    const geoTz = require('geo-tz')
+    const { find } = require('geo-tz')
 
-    geoTz(47.650499, -122.350070)  // ['America/Los_Angeles']
-    geoTz(43.839319, 87.526148)  // ['Asia/Shanghai', 'Asia/Urumqi']
+    find(47.650499, -122.350070)  // ['America/Los_Angeles']
+    find(43.839319, 87.526148)  // ['Asia/Shanghai', 'Asia/Urumqi']
 ```
 
 ## API Docs:
 
+As of Version 7, there is no longer a default import. The `find` function should be used instead.
+
 As of Version 5, the API now returns a list of possible timezones. There are certain coordinates where the timekeeping method will depend on the person you ask. Also, another case where 2 or more timezones could be returned is when a request is made with a coordinate that happens to be exactly on the border between two or more timezones.
 
-### geoTz(lat, lon)
+### find(lat, lon)
 
 Returns the timezone names found at `lat`, `lon`.  The timezone names will be the timezone identifiers as defined in the [timezone database](https://www.iana.org/time-zones).  The underlying geographic data is obtained from the [timezone-boudary-builder](https://github.com/evansiroky/timezone-boundary-builder) project.
 
@@ -28,7 +30,7 @@ This library does an exact geographic lookup which has tradeoffs.  It is perhaps
 
 The data is indexed for fast analysis by caching subregions of geographic data when a precise lookup is needed.
 
-### geoTz.setCache(options)
+### setCache(options)
 
 By default, geoTz lazy-loads exact lookup data into an unexpiring cache. The `setCache` method can be used to change the caching behavior using the following options:
 
@@ -38,10 +40,10 @@ By default, geoTz lazy-loads exact lookup data into an unexpiring cache. The `se
 Examples:
 
 ```js
-geoTz.setCache({ preload: true }) // preloads all files
+setCache({ preload: true }) // preloads all files
 
 let map = new Map();
-geoTz.setCache({ store: map }) // pass a Map-like storage object
+setCache({ store: map }) // pass a Map-like storage object
 ```
 
 ## Limitations

--- a/package.json
+++ b/package.json
@@ -19,10 +19,6 @@
     "node": ">=12"
   },
   "source": "src/find.ts",
-  "exports": {
-    "require": "./dist/geo-tz.js",
-    "default": "./dist/geo-tz.modern.js"
-  },
   "main": "./dist/geo-tz.js",
   "module": "./dist/geo-tz.module.js",
   "unpkg": "./dist/geo-tz.umd.js",

--- a/src/find.ts
+++ b/src/find.ts
@@ -134,7 +134,7 @@ function loadFeatures(
  * @param lon longitue (must be >= -180 and <=180)
  * @returns An array of string of TZIDs at the given coordinate.
  */
-export default function getTimezone(lat: number, lon: number): string[] {
+export function find(lat: number, lon: number): string[] {
   const originalLon = lon
 
   let err

--- a/tests/find.test.ts
+++ b/tests/find.test.ts
@@ -2,7 +2,7 @@
 
 import { assert } from 'chai'
 
-import geoTz, { preCache } from '../src/find'
+import { find, preCache } from '../src/find'
 import { oceanZones } from '../src/oceanUtils'
 
 const issueCoords = require('./fixtures/issues.json')
@@ -20,7 +20,7 @@ function assertTzResultContainsTzs(lat, lon, tzs) {
   if (typeof tzs === 'string') {
     tzs = [tzs]
   }
-  const result = geoTz(lat, lon)
+  const result = find(lat, lon)
   assert.isArray(result)
   assert.sameMembers(result, tzs)
 }
@@ -89,7 +89,7 @@ describe('find tests', function () {
       const timingStr = 'find tz of ' + count + ' random european positions'
       console.time(timingStr)
       for (let i = 0; i < count; i++) {
-        geoTz(
+        find(
           europeTopLeft[0] +
             Math.random() * (europeBottomRight[0] - europeTopLeft[0]),
           europeTopLeft[1] +


### PR DESCRIPTION
Fixes #129

microbundle is not happy with the mixing of default and named exports. It seems the easiest thing to do here is make the default export a named export.

This is probably a breaking change from v7.0.0, but since it was released not long ago and not really working all that well anyways, I'm just calling this a fix and assuming this named export thing should've been a breaking change that landed in v7.0.0.

This is probably a violation of SEMVER in a strict sense, so I apologize to anyone who already made workarounds for what was in v7.0.0.