### PR TITLE
feat: allow data dir to be moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,17 @@ setCache({ store: map }) // pass a Map-like storage object
 
 ### Performance
 
-This library relies on reading a large data file from disk to perform exact geographic lookups. Therefore, it is not intended to be used in the browser and may have issues with bundlers if they don't include the necessary file.
+This library relies on reading a large data file from disk to perform exact geographic lookups. Therefore, it is not intended to be used in the browser and may have issues with bundlers (see below).
+
+### Bundlers
+
+Because this library reads the [`data/`](/data/) directory from disk at runtime, it would typically not be included by standard bundling tools and needs to be copied somewhere explicitly after bundling your JavaScript code. Once you have a location for the `data/` directory after bundling, the `GEO_TZ_DATA_PATH` environment variable can be set for this library to read from that directory.
 
 ### Accuracy of Output
 
-The underlying data is obtained from the [timezone-boudary-builder](https://github.com/evansiroky/timezone-boundary-builder) project. The data from that project is mostly sourced from OpenStreetMap which is editable by anyone. In most cases, the timezone boundaries follow officially observed boundaries, but often times some communities near timezone boundaries may follow whichever timekeeping method works best for them.
+The underlying data is obtained from the [timezone-boundary-builder](https://github.com/evansiroky/timezone-boundary-builder) project. The data from that project is mostly sourced from OpenStreetMap which is editable by anyone. In most cases, the timezone boundaries follow officially observed boundaries, but often times some communities near timezone boundaries may follow whichever timekeeping method works best for them.
 
-The boundaries in the ocean come from the [timezone-boudary-builder](https://github.com/evansiroky/timezone-boundary-builder) project which only includes territorial waters and not exclusive economic zones. Additionally, special cases where the GPS coordinate falls with an area of [Terra nullius](https://en.wikipedia.org/wiki/Terra_nullius) will also have an ocean zone(s) returned.
+The boundaries in the ocean come from the [timezone-boundary-builder](https://github.com/evansiroky/timezone-boundary-builder) project which only includes territorial waters and not exclusive economic zones. Additionally, special cases where the GPS coordinate falls with an area of [Terra nullius](https://en.wikipedia.org/wiki/Terra_nullius) will also have an ocean zone(s) returned.
 
 The resulting timezone identifiers will represent the timekeeping method as is cataloged to the best of the knowledge of the maintainers of the timezone database. This could be wrong in the past (especially prior to 1970) and could change in the future should an area change the way they keep track of time.
 

--- a/src/find-1970.ts
+++ b/src/find-1970.ts
@@ -3,13 +3,10 @@ import * as path from 'path'
 import type { CacheOptions } from './find'
 import { findUsingDataset, setCacheLevel } from './find'
 
+const DATA_PATH =
+  process.env.GEO_TZ_DATA_PATH || path.join(__dirname, '..', 'data')
 const TZ_DATA = require('../data/timezones-1970.geojson.index.json')
-const FEATURE_FILE_PATH = path.join(
-  __dirname,
-  '..',
-  'data',
-  'timezones-1970.geojson.geo.dat',
-)
+const FEATURE_FILE_PATH = path.join(DATA_PATH, 'timezones-1970.geojson.geo.dat')
 let featureCache
 
 /**

--- a/src/find-all.ts
+++ b/src/find-all.ts
@@ -3,13 +3,10 @@ import * as path from 'path'
 import type { CacheOptions } from './find'
 import { findUsingDataset, setCacheLevel } from './find'
 
+const DATA_PATH =
+  process.env.GEO_TZ_DATA_PATH || path.join(__dirname, '..', 'data')
 const TZ_DATA = require('../data/timezones.geojson.index.json')
-const FEATURE_FILE_PATH = path.join(
-  __dirname,
-  '..',
-  'data',
-  'timezones.geojson.geo.dat',
-)
+const FEATURE_FILE_PATH = path.join(DATA_PATH, 'timezones.geojson.geo.dat')
 let featureCache
 
 /**

--- a/src/find-now.ts
+++ b/src/find-now.ts
@@ -3,13 +3,10 @@ import * as path from 'path'
 import type { CacheOptions } from './find'
 import { findUsingDataset, setCacheLevel } from './find'
 
+const DATA_PATH =
+  process.env.GEO_TZ_DATA_PATH || path.join(__dirname, '..', 'data')
 const TZ_DATA = require('../data/timezones-now.geojson.index.json')
-const FEATURE_FILE_PATH = path.join(
-  __dirname,
-  '..',
-  'data',
-  'timezones-now.geojson.geo.dat',
-)
+const FEATURE_FILE_PATH = path.join(DATA_PATH, 'timezones-now.geojson.geo.dat')
 let featureCache
 
 /**


### PR DESCRIPTION
I'm running into the same issue as #159 due to using a build process which bundles all of my code and dependencies for AWS Lambda functions. That build process means that the JSON files within the `data` dir of this package are bundled automatically because they use `require`, but the `.dat` files are not since they're loaded at runtime using `fs`.

I _can_ copy the `data` dir into my build folder using `copy-webpack-plugin` (or similar for rollup/esbuild/vite processes) so it is available to the runtime, but after bundling, the location of the `geo-tz` JS would be in an unexpected place so the `../data` location it's looking for is most likely going to be incorrect. In my case, this package ended up in the root folder of my Lambda bundle, so `../data` was **outside** of the file system I had access to modify. For AWS Lambda specifically, we can also make use of [layers](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html) to store static dependencies, but the path will again most likely not be available to the `../data` path this package expects.

To remedy this issue, this PR adds support for a `GEO_TZ_DATA_PATH` environment variable that allows the `data` directory to be moved or renamed as needed for each use case (his is effectively the same solution as #140, but updated to support the different data sets added in #162/#163).