### PR TITLE
Make cache type less strict

### DIFF
--- a/src/find.ts
+++ b/src/find.ts
@@ -7,6 +7,11 @@ import Pbf from 'pbf'
 
 import { getTimezoneAtSea, oceanZones } from './oceanUtils'
 
+type MapLike = {
+  get(key: string): any
+  set(key: string, value: any): void
+}
+
 export type CacheOptions = {
   /**
    * If set to true, all features will be loaded into memory to shorten future lookup
@@ -16,7 +21,7 @@ export type CacheOptions = {
   /**
    * Must be a map-like object with a `get` and `set` function.
    */
-  store?: Map<string, any>
+  store?: MapLike
 }
 
 /**
@@ -69,7 +74,7 @@ function _preCache(
   tzData: any,
   featureFilePath: string,
   featureFileFd: number,
-  featureCache: Map<string, any>,
+  featureCache: MapLike,
 ) {
   // shoutout to github user @magwo for an initial version of this recursive function
   function preloadFeaturesRecursive(curTzData, quadPos: string) {
@@ -147,7 +152,7 @@ function loadFeatures(
  */
 export function findUsingDataset(
   tzData: any,
-  featureCache: any,
+  featureCache: MapLike,
   featureFilePath: string,
   lat: number,
   lon: number,


### PR DESCRIPTION
I'm using `mnemonist/lru-map` to store the cache in my node project, like so:


```ts
import { find, setCache } from 'geo-tz/dist/find-all';
import LRUMap from 'mnemonist/lru-map';

// geo-tz can hold a total of 21,000 items in memory, costing 1.5GB when full
// The LRUMap of 5,000 items limits its size to ~400MB
const cacheStore = new LRUMap(5000);

// We need to type-cast because the expected type is a Map
// but it only expects a map-like entity with get and set methods
setCache({ store: cacheStore as unknown as Map<string, any> });
```

I would like to remove this type-casting, otherwise, I get this error:

![CleanShot 2024-09-30 at 11 48 56@2x](https://github.com/user-attachments/assets/0c1bed67-a13e-4b83-b305-1c83787389f9)

I created this PR to relax the cache type to something that accepts another map-like entity like the `LRUMap.`

After the changes introduced by this PR, my code looks like this instead:

```ts
import { find, setCache } from 'geo-tz/dist/find-all';
import LRUMap from 'mnemonist/lru-map';

// geo-tz can hold a total of 21,000 items in memory, costing 1.5GB when full
// The LRUMap of 5,000 items limits its size to ~400MB
const cacheStore = new LRUMap(5000);

setCache({ store: cacheStore });
```
