### PR TITLE
[fix] override point-in-polygon-pacakges which causing ESM error

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,5 +110,8 @@
     "@turf/helpers": "^7.1.0",
     "geobuf": "^3.0.2",
     "pbf": "^3.2.1"
+  },
+  "overrides": {  
+    "point-in-polygon-hao": "1.1.0"  
   }
 }


### PR DESCRIPTION
Honestly, I am not sure if this is the proper fix for the solution or not, either this or trying to downgrade @turf/boolean-point-in-polygon package itself. 

Issue : [182](https://github.com/evansiroky/node-geo-tz/issues/182)